### PR TITLE
feat: add dodecahedron CA logic

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,3 +4,16 @@ html, body, #root, .scene-container {
   margin: 0;
   padding: 0;
 }
+
+.controls {
+  position: absolute;
+  top: 0;
+  left: 0;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.8);
+  font-family: sans-serif;
+}
+
+.controls label {
+  margin-right: 8px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,32 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
 import './App.css'
 
+function parseRule(text: string): number[] {
+  return text
+    .split(',')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !Number.isNaN(n))
+}
+
 function App() {
   const mountRef = useRef<HTMLDivElement | null>(null)
+  const cellsRef = useRef<number[]>([])
+  const neighborsRef = useRef<number[][]>([])
+  const meshesRef = useRef<THREE.Mesh[]>([])
+  const [bornText, setBornText] = useState('3')
+  const [surviveText, setSurviveText] = useState('2,3')
+  const [born, setBorn] = useState<number[]>([3])
+  const [survive, setSurvive] = useState<number[]>([2, 3])
+  const [running, setRunning] = useState(false)
+
+  useEffect(() => {
+    setBorn(parseRule(bornText))
+  }, [bornText])
+
+  useEffect(() => {
+    setSurvive(parseRule(surviveText))
+  }, [surviveText])
 
   useEffect(() => {
     const container = mountRef.current!
@@ -23,9 +46,11 @@ function App() {
     const dodecahedron = new THREE.Mesh(dodecaGeometry, dodecaMaterial)
     scene.add(dodecahedron)
 
+    const icoGeometry = new THREE.IcosahedronGeometry(1)
     const sphereGeometry = new THREE.SphereGeometry(0.05, 16, 16)
-    const sphereMaterial = new THREE.MeshBasicMaterial({ color: 0xffffff })
-    const positions = dodecaGeometry.getAttribute('position')
+    const deadMaterial = new THREE.MeshBasicMaterial({ color: 0x222222 })
+    const aliveMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+    const positions = icoGeometry.getAttribute('position') as THREE.BufferAttribute
     const vertices: THREE.Vector3[] = []
     for (let i = 0; i < positions.count; i++) {
       const vertex = new THREE.Vector3().fromBufferAttribute(positions, i)
@@ -33,11 +58,30 @@ function App() {
         vertices.push(vertex.clone())
       }
     }
-    vertices.forEach((v) => {
-      const sphere = new THREE.Mesh(sphereGeometry, sphereMaterial)
+
+    const neighborMap: number[][] = vertices.map(() => [])
+    const index = icoGeometry.index!.array as ArrayLike<number>
+    for (let i = 0; i < index.length; i += 3) {
+      const a = index[i], b = index[i + 1], c = index[i + 2]
+      neighborMap[a].push(b, c)
+      neighborMap[b].push(a, c)
+      neighborMap[c].push(a, b)
+    }
+    neighborMap.forEach((arr, i) => {
+      neighborMap[i] = Array.from(new Set(arr))
+    })
+
+    const cells = vertices.map(() => (Math.random() > 0.5 ? 1 : 0))
+    cellsRef.current = cells
+    neighborsRef.current = neighborMap
+    const meshes = vertices.map((v, i) => {
+      const material = cells[i] ? aliveMaterial.clone() : deadMaterial.clone()
+      const sphere = new THREE.Mesh(sphereGeometry, material)
       sphere.position.copy(v)
       scene.add(sphere)
+      return sphere
     })
+    meshesRef.current = meshes
 
     const animate = () => {
       requestAnimationFrame(animate)
@@ -62,7 +106,49 @@ function App() {
     }
   }, [])
 
-  return <div ref={mountRef} className="scene-container" />
+  const tick = useCallback(() => {
+    const cells = cellsRef.current
+    const neighbors = neighborsRef.current
+    const next = cells.map((cell, i) => {
+      const count = neighbors[i].reduce((sum, n) => sum + cells[n], 0)
+      return cell ? (survive.includes(count) ? 1 : 0) : born.includes(count) ? 1 : 0
+    })
+    cellsRef.current = next
+    meshesRef.current.forEach((mesh, i) => {
+      const mat = mesh.material as THREE.MeshBasicMaterial
+      mat.color.set(next[i] ? 0xff0000 : 0x222222)
+    })
+  }, [born, survive])
+
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [running, tick])
+
+  return (
+    <div>
+      <div ref={mountRef} className="scene-container" />
+      <div className="controls">
+        <label>
+          born:
+          <input
+            value={bornText}
+            onChange={(e) => setBornText(e.target.value)}
+          />
+        </label>
+        <label>
+          survive:
+          <input
+            value={surviveText}
+            onChange={(e) => setSurviveText(e.target.value)}
+          />
+        </label>
+        <button onClick={() => setRunning((r) => !r)}>{running ? 'Stop' : 'Start'}</button>
+        <button onClick={tick}>Step</button>
+      </div>
+    </div>
+  )
 }
 
 export default App


### PR DESCRIPTION
## Summary
- integrate Icosahedron-based neighbor calculations for dodecahedral CA
- add born/survive rule ticker with runtime controls

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68bafb59293883209f6c8a4fe195aad3