### PR TITLE
docs: expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Cellular Automaton
 
 Scaffolded with Vite + React + TypeScript. Includes a Three.js scene rendering a rotating dodecahedron with spheres on its vertices.
+
+## Scripts
+- `pnpm install` installs dependencies.
+- `pnpm run dev` starts a development server at http://localhost:5173.
+- `pnpm build` builds the production bundle.
+
+## Hotkeys
+No keyboard shortcuts are implemented; use the Start/Stop and Step buttons in the UI.
+
+## Deployment
+The latest build is deployed at https://cellular-automaton.vercel.app.
+
+## References
+- Platonic solids: https://en.wikipedia.org/wiki/Platonic_solid
+- Three.js: https://threejs.org/docs/
+- Vite: https://vite.dev/guide/


### PR DESCRIPTION
## Summary
- document dev/build scripts and deployment link
- clarify absence of hotkeys
- add references for Platonic solids, Three.js, and Vite

## Testing
- `pnpm run test` (missing script)
- `pnpm lint`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68bafdad408883209cd460c09ef734f8