### PR TITLE
fix: use relative base path for assets

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,8 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/cellular-automaton/',
+  // Use a relative base so that built assets can be served from any path
+  base: './',
   plugins: [react()],
   test: {
     environment: 'node',


### PR DESCRIPTION
## Summary
- serve built assets via relative paths so deployment folders work without 404s

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68bb023668848320ad1c35d6545e7228