### PR TITLE
fix: set Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,8 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  // Use a relative base so that built assets can be served from any path
-  base: './',
+  // Use explicit base for GitHub Pages deployment
+  base: '/cellular-automaton/',
   plugins: [react()],
   test: {
     environment: 'node',


### PR DESCRIPTION
## Summary
- set explicit Vite `base` to `/cellular-automaton/` for correct asset paths on GitHub Pages

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68bb0db8ae388320b7b9c44b2cdb291b