### PR TITLE
fix: upload docs folder for pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,8 @@ jobs:
       - run: pnpm build
       - uses: actions/upload-pages-artifact@v4
         with:
-          path: dist
+          # Vite outputs the build artifacts to `docs`
+          path: docs
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow to upload `docs` folder built by Vite

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68bb1be5f40083208e28610da69a67e2