### PR TITLE
fix: rely on packageManager for pnpm version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
       - run: pnpm install
       - run: pnpm build
       - uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary
- fix CI build by removing conflicting pnpm version declaration
- rely on package.json's `packageManager` field to pin pnpm

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68bbf1a8ff9083208115d21c9dc662a8