### PR TITLE
feat: add dodecahedron neighbor generator

### DIFF
--- a/src/ca.test.ts
+++ b/src/ca.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { generateIcosahedronNeighbors, step } from './ca'
+import { generateDodecahedronNeighbors, generateIcosahedronNeighbors, step } from './ca'
 
 describe('generateIcosahedronNeighbors', () => {
   const { neighbors } = generateIcosahedronNeighbors()
@@ -8,6 +8,23 @@ describe('generateIcosahedronNeighbors', () => {
   })
   it('each vertex has 5 neighbors', () => {
     neighbors.forEach((list) => expect(list).toHaveLength(5))
+  })
+  it('neighbor relation is symmetric', () => {
+    neighbors.forEach((list, i) => {
+      list.forEach((n) => {
+        expect(neighbors[n]).toContain(i)
+      })
+    })
+  })
+})
+
+describe('generateDodecahedronNeighbors', () => {
+  const { neighbors } = generateDodecahedronNeighbors()
+  it('creates 20 vertices', () => {
+    expect(neighbors).toHaveLength(20)
+  })
+  it('each vertex has 3 neighbors', () => {
+    neighbors.forEach((list) => expect(list).toHaveLength(3))
   })
   it('neighbor relation is symmetric', () => {
     neighbors.forEach((list, i) => {

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -38,6 +38,47 @@ export function generateIcosahedronNeighbors(): {
   return { vertices, neighbors: neighborMap }
 }
 
+export function generateDodecahedronNeighbors(): {
+  vertices: THREE.Vector3[]
+  neighbors: number[][]
+} {
+  const dodeGeometry = new THREE.DodecahedronGeometry(1)
+  const edgeGeometry = new THREE.EdgesGeometry(dodeGeometry)
+  const positions = edgeGeometry.getAttribute('position') as THREE.BufferAttribute
+  const vertices: THREE.Vector3[] = []
+  const vertexMap = new Map<string, number>()
+  const neighborMap: number[][] = []
+
+  const getIndex = (v: THREE.Vector3): number => {
+    const key = v.toArray().join(',')
+    let idx = vertexMap.get(key)
+    if (idx === undefined) {
+      idx = vertices.length
+      vertexMap.set(key, idx)
+      vertices.push(v.clone())
+      neighborMap[idx] = []
+    }
+    return idx
+  }
+
+  for (let i = 0; i < positions.count; i += 2) {
+    const a = getIndex(new THREE.Vector3().fromBufferAttribute(positions, i))
+    const b = getIndex(new THREE.Vector3().fromBufferAttribute(positions, i + 1))
+    neighborMap[a].push(b)
+    neighborMap[b].push(a)
+  }
+
+  neighborMap.forEach((arr, i) => {
+    const dedup = Array.from(new Set(arr))
+    if (dedup.length !== 3) {
+      throw new Error(`Vertex ${i} expected 3 neighbors, got ${dedup.length}`)
+    }
+    neighborMap[i] = dedup
+  })
+
+  return { vertices, neighbors: neighborMap }
+}
+
 export function step(
   cells: number[],
   neighbors: number[][],


### PR DESCRIPTION
## Summary
- add `generateDodecahedronNeighbors` using `DodecahedronGeometry` and `EdgesGeometry`
- verify neighbors deduplicate to degree 3
- test coverage for new generator

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68bbf6598b608320b939530b360dec20