### PR TITLE
feat: dispose Three.js resources on cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,10 +81,24 @@ function App() {
     }
     window.addEventListener('resize', handleResize)
 
-    return () => {
-      window.removeEventListener('resize', handleResize)
-      container.removeChild(renderer.domElement)
-    }
+      return () => {
+        window.removeEventListener('resize', handleResize)
+        renderer.dispose()
+        dodecaGeometry.dispose()
+        dodecaMaterial.dispose()
+        meshesRef.current.forEach((mesh) => {
+          mesh.geometry.dispose()
+          if (Array.isArray(mesh.material)) {
+            mesh.material.forEach((m) => m.dispose())
+          } else {
+            mesh.material.dispose()
+          }
+        })
+        cellsRef.current = []
+        neighborsRef.current = []
+        meshesRef.current = []
+        container.removeChild(renderer.domElement)
+      }
   }, [])
 
   const tick = useCallback(() => {


### PR DESCRIPTION
## Summary
- dispose Three.js renderer and dodecahedron resources on effect cleanup
- release sphere mesh geometries and materials to avoid leaks
- clear refs to cells, neighbors and meshes

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev` (terminated)


------
https://chatgpt.com/codex/tasks/task_b_68bbfe8d32788320a79d2bce084d9010