### PR TITLE
feat: validate rule input with error handling

### DIFF
--- a/src/parseRule.test.ts
+++ b/src/parseRule.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseRule } from './App'
+
+describe('parseRule', () => {
+  it('filters negatives and numbers greater than 12', () => {
+    const result = parseRule('-1,5,13')
+    expect(result.values).toEqual([5])
+    expect(result.valid).toBe(false)
+  })
+
+  it('removes duplicates and validates', () => {
+    const result = parseRule('2,2,3')
+    expect(result.values).toEqual([2, 3])
+    expect(result.valid).toBe(true)
+  })
+
+  it('detects invalid inputs', () => {
+    const result = parseRule('a,b')
+    expect(result.values).toEqual([])
+    expect(result.valid).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- validate rule text and reject negatives or numbers above 12
- show error messages and fall back to defaults on invalid input
- add tests for rule parsing

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68bbff9aaa688320a3bc903476504dec