### PR TITLE
feat: sort neighbor lists and assert symmetry

### DIFF
--- a/src/ca.test.ts
+++ b/src/ca.test.ts
@@ -18,6 +18,12 @@ describe('generateIcosahedronNeighbors', () => {
       })
     })
   })
+  it('neighbor order is deterministic', () => {
+    neighbors.forEach((list) => {
+      const sorted = [...list].sort((a, b) => a - b)
+      expect(list).toEqual(sorted)
+    })
+  })
 })
 
 describe('generateDodecahedronNeighbors', () => {
@@ -35,6 +41,12 @@ describe('generateDodecahedronNeighbors', () => {
       unique.forEach((n) => {
         expect(neighbors[n]).toContain(i)
       })
+    })
+  })
+  it('neighbor order is deterministic', () => {
+    neighbors.forEach((list) => {
+      const sorted = [...list].sort((a, b) => a - b)
+      expect(list).toEqual(sorted)
     })
   })
 })

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -32,7 +32,15 @@ export function generateIcosahedronNeighbors(): {
   }
 
   neighborMap.forEach((arr, i) => {
-    neighborMap[i] = Array.from(new Set(arr))
+    neighborMap[i] = Array.from(new Set(arr)).sort((a, b) => a - b)
+  })
+
+  neighborMap.forEach((arr, i) => {
+    arr.forEach((j) => {
+      if (!neighborMap[j].includes(i)) {
+        throw new Error(`Neighbor symmetry broken between ${i} and ${j}`)
+      }
+    })
   })
 
   return { vertices, neighbors: neighborMap }
@@ -69,11 +77,19 @@ export function generateDodecahedronNeighbors(): {
   }
 
   neighborMap.forEach((arr, i) => {
-    const dedup = Array.from(new Set(arr))
+    const dedup = Array.from(new Set(arr)).sort((a, b) => a - b)
     if (dedup.length !== 3) {
       throw new Error(`Vertex ${i} expected 3 neighbors, got ${dedup.length}`)
     }
     neighborMap[i] = dedup
+  })
+
+  neighborMap.forEach((arr, i) => {
+    arr.forEach((j) => {
+      if (!neighborMap[j].includes(i)) {
+        throw new Error(`Neighbor symmetry broken between ${i} and ${j}`)
+      }
+    })
   })
 
   return { vertices, neighbors: neighborMap }


### PR DESCRIPTION
## Summary
- sort deduplicated neighbor lists for deterministic order
- assert neighbor list symmetry in polyhedron generators
- test neighbor ordering to ensure determinism

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68bc01fd35648320889ed42f9e04a46c