### PR TITLE
feat: add optional output array for CA step

### DIFF
--- a/bench.ts
+++ b/bench.ts
@@ -1,0 +1,31 @@
+import { step } from './src/ca'
+
+const N = 100000
+const iterations = 100
+const born = [1]
+const survive = [1]
+const neighbors = Array.from({ length: N }, (_, i) => [
+  (i - 1 + N) % N,
+  (i + 1) % N,
+])
+const initial = Array.from({ length: N }, () => (Math.random() > 0.5 ? 1 : 0))
+
+function run(useOut: boolean) {
+  let a = initial.slice()
+  let b = new Array<number>(N).fill(0)
+  const start = performance.now()
+  for (let i = 0; i < iterations; i++) {
+    if (useOut) {
+      step(a, neighbors, born, survive, b)
+      ;[a, b] = [b, a]
+    } else {
+      a = step(a, neighbors, born, survive)
+    }
+  }
+  const time = performance.now() - start
+  const mem = process.memoryUsage().heapUsed / 1024 / 1024
+  console.log(useOut ? 'with out' : 'without out', { time, mem })
+}
+
+run(false)
+run(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ function App() {
   const cellsRef = useRef<number[]>([])
   const neighborsRef = useRef<number[][]>([])
   const meshesRef = useRef<THREE.Mesh[]>([])
+  const bufferRef = useRef<number[]>([])
   const [bornText, setBornText] = useState('3')
   const [surviveText, setSurviveText] = useState('2,3')
   const [born, setBorn] = useState<number[]>(DEFAULT_BORN)
@@ -85,6 +86,7 @@ function App() {
     const cells = vertices.map(() => (Math.random() > 0.5 ? 1 : 0))
     cellsRef.current = cells
     neighborsRef.current = neighbors
+    bufferRef.current = new Array(cells.length).fill(0)
     const meshes = vertices.map((v, i) => {
       const material = cells[i] ? aliveMaterial.clone() : deadMaterial.clone()
       const sphere = new THREE.Mesh(sphereGeometry, material)
@@ -127,6 +129,7 @@ function App() {
         cellsRef.current = []
         neighborsRef.current = []
         meshesRef.current = []
+        bufferRef.current = []
         container.removeChild(renderer.domElement)
       }
   }, [])
@@ -134,7 +137,9 @@ function App() {
   const tick = useCallback(() => {
     const cells = cellsRef.current
     const neighbors = neighborsRef.current
-    const next = step(cells, neighbors, born, survive)
+    const buffer = bufferRef.current
+    const next = step(cells, neighbors, born, survive, buffer)
+    bufferRef.current = cells
     cellsRef.current = next
     meshesRef.current.forEach((mesh, i) => {
       const mat = mesh.material as THREE.MeshBasicMaterial

--- a/src/ca.test.ts
+++ b/src/ca.test.ts
@@ -85,4 +85,13 @@ describe('step', () => {
     const next = step(cells, neighborsOver, born, survive)
     expect(next[0]).toBe(0)
   })
+
+  it('writes output to provided array', () => {
+    const cells = [0, 1, 1, 1]
+    const out: number[] = []
+    const next = step(cells, tetraNeighbors, born, survive, out)
+    expect(next).toBe(out)
+    expect(next[0]).toBe(1)
+    expect(cells[0]).toBe(0)
+  })
 })

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -100,9 +100,21 @@ export function step(
   neighbors: number[][],
   born: number[],
   survive: number[],
+  out?: number[],
 ): number[] {
-  return cells.map((cell, i) => {
+  const result = out ?? new Array<number>(cells.length)
+  if (result.length !== cells.length) result.length = cells.length
+
+  for (let i = 0; i < cells.length; i++) {
     const count = neighbors[i].reduce((sum, n) => sum + cells[n], 0)
-    return cell ? (survive.includes(count) ? 1 : 0) : born.includes(count) ? 1 : 0
-  })
+    result[i] = cells[i]
+      ? survive.includes(count)
+        ? 1
+        : 0
+      : born.includes(count)
+        ? 1
+        : 0
+  }
+
+  return result
 }


### PR DESCRIPTION
## Summary
- allow `step` to write results into a provided array
- reuse a buffer array in `App` to avoid allocations between steps
- cover output-buffer logic with tests

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`
- `npx tsx bench.ts`

------
https://chatgpt.com/codex/tasks/task_b_68bc047b27ec8320bafecd115ac8fc41