### PR TITLE
feat: add FCC lattice and instanced rendering

### DIFF
--- a/src/ca.test.ts
+++ b/src/ca.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { generateDodecahedronNeighbors, generateIcosahedronNeighbors, step } from './ca'
+import { generateDodecahedronNeighbors, generateIcosahedronNeighbors, generateFCCLattice, step } from './ca'
 
 describe('generateIcosahedronNeighbors', () => {
   const { neighbors } = generateIcosahedronNeighbors()
@@ -33,6 +33,33 @@ describe('generateDodecahedronNeighbors', () => {
   })
   it('each vertex has 3 neighbors', () => {
     neighbors.forEach((list) => expect(list).toHaveLength(3))
+  })
+  it('neighbor relation is symmetric', () => {
+    neighbors.forEach((list, i) => {
+      const unique = new Set(list)
+      expect(unique.size).toBe(list.length)
+      unique.forEach((n) => {
+        expect(neighbors[n]).toContain(i)
+      })
+    })
+  })
+  it('neighbor order is deterministic', () => {
+    neighbors.forEach((list) => {
+      const sorted = [...list].sort((a, b) => a - b)
+      expect(list).toEqual(sorted)
+    })
+  })
+})
+
+describe('generateFCCLattice', () => {
+  const { positions, neighbors } = generateFCCLattice(1)
+  const coords = positions.map((v) => [v.x, v.y, v.z])
+  it('positions have even parity', () => {
+    coords.forEach(([x, y, z]) => expect(Math.abs((x + y + z) % 2)).toBe(0))
+  })
+  it('center has 12 neighbors', () => {
+    const center = coords.findIndex(([x, y, z]) => x === 0 && y === 0 && z === 0)
+    expect(neighbors[center]).toHaveLength(12)
   })
   it('neighbor relation is symmetric', () => {
     neighbors.forEach((list, i) => {

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -95,6 +95,62 @@ export function generateDodecahedronNeighbors(): {
   return { vertices, neighbors: neighborMap }
 }
 
+export function generateFCCLattice(radius: number): {
+  positions: THREE.Vector3[]
+  neighbors: number[][]
+} {
+  const positions: THREE.Vector3[] = []
+  const indexMap = new Map<string, number>()
+  const neighborMap: number[][] = []
+
+  for (let x = -radius; x <= radius; x++) {
+    for (let y = -radius; y <= radius; y++) {
+      for (let z = -radius; z <= radius; z++) {
+        if ((x + y + z) % 2 !== 0) continue
+        const v = new THREE.Vector3(x, y, z)
+        const idx = positions.length
+        positions.push(v)
+        indexMap.set(v.toArray().join(','), idx)
+        neighborMap[idx] = []
+      }
+    }
+  }
+
+  const offsets = [
+    [1, 1, 0],
+    [1, -1, 0],
+    [-1, 1, 0],
+    [-1, -1, 0],
+    [1, 0, 1],
+    [1, 0, -1],
+    [-1, 0, 1],
+    [-1, 0, -1],
+    [0, 1, 1],
+    [0, 1, -1],
+    [0, -1, 1],
+    [0, -1, -1],
+  ] as const
+
+  positions.forEach((v, i) => {
+    offsets.forEach(([dx, dy, dz]) => {
+      const key = [v.x + dx, v.y + dy, v.z + dz].join(',')
+      const idx = indexMap.get(key)
+      if (idx !== undefined) neighborMap[i].push(idx)
+    })
+    neighborMap[i].sort((a, b) => a - b)
+  })
+
+  neighborMap.forEach((arr, i) => {
+    arr.forEach((j) => {
+      if (!neighborMap[j].includes(i)) {
+        throw new Error(`Neighbor symmetry broken between ${i} and ${j}`)
+      }
+    })
+  })
+
+  return { positions, neighbors: neighborMap }
+}
+
 export function step(
   cells: number[],
   neighbors: number[][],


### PR DESCRIPTION
## Summary
- add FCC lattice generator with even-parity positions and neighbor lists
- replace single polyhedron with instanced mesh rendering over lattice
- add tests for FCC lattice parity and neighbor symmetry

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev` (launch + kill)


------
https://chatgpt.com/codex/tasks/task_b_68bc06c4aa4c8320aa1bac77680f21c9