### PR TITLE
feat: use rhombic dodecahedron cells

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
-import { generateFCCLattice, step } from './ca'
+import { createRhombicDodecahedronGeometry, generateFCCLattice, step } from './ca'
 import './App.css'
 
 const DEFAULT_BORN = [3]
@@ -74,13 +74,18 @@ function App() {
     container.appendChild(renderer.domElement)
 
     const { positions, neighbors } = generateFCCLattice(3)
-    const sphereGeometry = new THREE.SphereGeometry(0.2, 16, 16)
-    const material = new THREE.MeshBasicMaterial({ vertexColors: true })
+    const cellGeometry = createRhombicDodecahedronGeometry(0.2)
+    const material = new THREE.MeshStandardMaterial({ vertexColors: true, metalness: 0, roughness: 1 })
     const mesh = new THREE.InstancedMesh(
-      sphereGeometry,
+      cellGeometry,
       material,
       positions.length,
     )
+    const ambient = new THREE.AmbientLight(0xffffff, 0.4)
+    scene.add(ambient)
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8)
+    dir.position.set(5, 5, 5)
+    scene.add(dir)
     const cells = positions.map(() => (Math.random() > 0.5 ? 1 : 0))
     cellsRef.current = cells
     neighborsRef.current = neighbors
@@ -90,7 +95,7 @@ function App() {
     positions.forEach((v, i) => {
       matrix.setPosition(v)
       mesh.setMatrixAt(i, matrix)
-      color.set(cells[i] ? 0xff0000 : 0x222222)
+      color.set(cells[i] ? 0x00ff00 : 0x444444)
       mesh.setColorAt(i, color)
     })
     mesh.instanceMatrix.needsUpdate = true
@@ -145,7 +150,7 @@ function App() {
     if (mesh && mesh.instanceColor) {
       const color = new THREE.Color()
       next.forEach((v, i) => {
-        color.set(v ? 0xff0000 : 0x222222)
+        color.set(v ? 0x00ff00 : 0x444444)
         mesh.setColorAt(i, color)
       })
       mesh.instanceColor.needsUpdate = true

--- a/src/ca.test.ts
+++ b/src/ca.test.ts
@@ -1,5 +1,19 @@
+import * as THREE from 'three'
 import { describe, expect, it } from 'vitest'
-import { generateDodecahedronNeighbors, generateIcosahedronNeighbors, generateFCCLattice, step } from './ca'
+import { createRhombicDodecahedronGeometry, generateDodecahedronNeighbors, generateIcosahedronNeighbors, generateFCCLattice, step } from './ca'
+
+describe('createRhombicDodecahedronGeometry', () => {
+  const geometry = createRhombicDodecahedronGeometry()
+  it('has 14 unique vertices', () => {
+    const pos = geometry.getAttribute('position') as THREE.BufferAttribute
+    const vertices = new Set<string>()
+    for (let i = 0; i < pos.count; i++) {
+      const v = new THREE.Vector3().fromBufferAttribute(pos, i)
+      vertices.add(v.toArray().map((n) => n.toFixed(3)).join(','))
+    }
+    expect(vertices.size).toBe(14)
+  })
+})
 
 describe('generateIcosahedronNeighbors', () => {
   const { neighbors } = generateIcosahedronNeighbors()

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import { ConvexGeometry } from 'three/examples/jsm/geometries/ConvexGeometry.js'
 
 export function generateIcosahedronNeighbors(): {
   vertices: THREE.Vector3[]
@@ -93,6 +94,28 @@ export function generateDodecahedronNeighbors(): {
   })
 
   return { vertices, neighbors: neighborMap }
+}
+
+export function createRhombicDodecahedronGeometry(size = 1): THREE.BufferGeometry {
+  const vertices = [
+    new THREE.Vector3(1, 0, 0),
+    new THREE.Vector3(-1, 0, 0),
+    new THREE.Vector3(0, 1, 0),
+    new THREE.Vector3(0, -1, 0),
+    new THREE.Vector3(0, 0, 1),
+    new THREE.Vector3(0, 0, -1),
+    new THREE.Vector3(0.5, 0.5, 0.5),
+    new THREE.Vector3(0.5, 0.5, -0.5),
+    new THREE.Vector3(0.5, -0.5, 0.5),
+    new THREE.Vector3(0.5, -0.5, -0.5),
+    new THREE.Vector3(-0.5, 0.5, 0.5),
+    new THREE.Vector3(-0.5, 0.5, -0.5),
+    new THREE.Vector3(-0.5, -0.5, 0.5),
+    new THREE.Vector3(-0.5, -0.5, -0.5),
+  ]
+  const geometry = new ConvexGeometry(vertices)
+  geometry.scale(size, size, size)
+  return geometry
 }
 
 export function generateFCCLattice(radius: number): {


### PR DESCRIPTION
## Summary
- add rhombic dodecahedron geometry helper
- render FCC lattice with rhombic dodecahedra instead of spheres
- color alive cells green and dead cells gray

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68bc0bef8d20832093f78da8d5e3d0e2