### PR TITLE
refactor: extract parseRule into dedicated module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,28 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import * as THREE from 'three'
 import { createRhombicDodecahedronGeometry, generateFCCLattice, step } from './ca'
+import { parseRule } from './ruleParser'
 import './App.css'
 
 const DEFAULT_BORN = [3]
 const DEFAULT_SURVIVE = [2, 3]
-
-// eslint-disable-next-line react-refresh/only-export-components
-export function parseRule(text: string): { values: number[]; valid: boolean } {
-  const parts = text.split(',')
-  const nums: number[] = []
-  let valid = parts.length > 0
-  for (const part of parts) {
-    const n = parseInt(part.trim(), 10)
-    if (Number.isNaN(n) || n < 0 || n > 12) {
-      valid = false
-      continue
-    }
-    nums.push(n)
-  }
-  const values = Array.from(new Set(nums))
-  if (values.length === 0) valid = false
-  return { values, valid }
-}
 
 function App() {
   const mountRef = useRef<HTMLDivElement | null>(null)

--- a/src/parseRule.test.ts
+++ b/src/parseRule.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseRule } from './App'
+import { parseRule } from './ruleParser'
 
 describe('parseRule', () => {
   it('filters negatives and numbers greater than 12', () => {

--- a/src/ruleParser.ts
+++ b/src/ruleParser.ts
@@ -1,0 +1,16 @@
+export function parseRule(text: string): { values: number[]; valid: boolean } {
+  const parts = text.split(',')
+  const nums: number[] = []
+  let valid = parts.length > 0
+  for (const part of parts) {
+    const n = parseInt(part.trim(), 10)
+    if (Number.isNaN(n) || n < 0 || n > 12) {
+      valid = false
+      continue
+    }
+    nums.push(n)
+  }
+  const values = Array.from(new Set(nums))
+  if (values.length === 0) valid = false
+  return { values, valid }
+}


### PR DESCRIPTION
## Summary
- move parseRule function into src/ruleParser.ts
- update imports in App and tests

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68bc12fa87e88320ab04f5f2c18149c9