### PR TITLE
refactor: optimize rule lookup with sets

### DIFF
--- a/src/ca.test.ts
+++ b/src/ca.test.ts
@@ -135,4 +135,12 @@ describe('step', () => {
     expect(next[0]).toBe(1)
     expect(cells[0]).toBe(0)
   })
+
+  it('handles duplicate rule entries', () => {
+    const cells = [0, 1, 1, 1]
+    const bornDup = [3, 3]
+    const surviveDup = [2, 3, 3]
+    const next = step(cells, tetraNeighbors, bornDup, surviveDup)
+    expect(next[0]).toBe(1)
+  })
 })

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -184,13 +184,16 @@ export function step(
   const result = out ?? new Array<number>(cells.length)
   if (result.length !== cells.length) result.length = cells.length
 
+  const bornSet = new Set(born)
+  const surviveSet = new Set(survive)
+
   for (let i = 0; i < cells.length; i++) {
     const count = neighbors[i].reduce((sum, n) => sum + cells[n], 0)
     result[i] = cells[i]
-      ? survive.includes(count)
+      ? surviveSet.has(count)
         ? 1
         : 0
-      : born.includes(count)
+      : bornSet.has(count)
         ? 1
         : 0
   }


### PR DESCRIPTION
## Summary
- use Set lookups for born and survive counts in `step`
- add test to ensure duplicate rule entries behave correctly

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`


------
https://chatgpt.com/codex/tasks/task_b_68bc476748ac8320bc4454040f5d66a4