### PR TITLE
refactor: hash lattice coordinates

### DIFF
--- a/src/ca.test.ts
+++ b/src/ca.test.ts
@@ -71,6 +71,10 @@ describe('generateFCCLattice', () => {
   it('positions have even parity', () => {
     coords.forEach(([x, y, z]) => expect(Math.abs((x + y + z) % 2)).toBe(0))
   })
+  it('has expected number of unique positions', () => {
+    const seen = new Set(coords.map((c) => c.join(',')))
+    expect(seen.size).toBe(13)
+  })
   it('center has 12 neighbors', () => {
     const center = coords.findIndex(([x, y, z]) => x === 0 && y === 0 && z === 0)
     expect(neighbors[center]).toHaveLength(12)
@@ -88,6 +92,17 @@ describe('generateFCCLattice', () => {
     neighbors.forEach((list) => {
       const sorted = [...list].sort((a, b) => a - b)
       expect(list).toEqual(sorted)
+    })
+  })
+  it('works for larger radius', () => {
+    const { positions: pos2, neighbors: neigh2 } = generateFCCLattice(2)
+    expect(pos2).toHaveLength(63)
+    const unique = new Set(pos2.map((v) => [v.x, v.y, v.z].join(',')))
+    expect(unique.size).toBe(pos2.length)
+    neigh2.forEach((list, i) => {
+      list.forEach((n) => {
+        expect(neigh2[n]).toContain(i)
+      })
     })
   })
 })

--- a/src/ca.ts
+++ b/src/ca.ts
@@ -123,8 +123,11 @@ export function generateFCCLattice(radius: number): {
   neighbors: number[][]
 } {
   const positions: THREE.Vector3[] = []
-  const indexMap = new Map<string, number>()
+  const indexMap = new Map<number, number>()
   const neighborMap: number[][] = []
+  const size = radius * 2 + 1
+  const hash = (x: number, y: number, z: number): number =>
+    ((x + radius) * size + (y + radius)) * size + (z + radius)
 
   for (let x = -radius; x <= radius; x++) {
     for (let y = -radius; y <= radius; y++) {
@@ -133,7 +136,7 @@ export function generateFCCLattice(radius: number): {
         const v = new THREE.Vector3(x, y, z)
         const idx = positions.length
         positions.push(v)
-        indexMap.set(v.toArray().join(','), idx)
+        indexMap.set(hash(x, y, z), idx)
         neighborMap[idx] = []
       }
     }
@@ -156,8 +159,7 @@ export function generateFCCLattice(radius: number): {
 
   positions.forEach((v, i) => {
     offsets.forEach(([dx, dy, dz]) => {
-      const key = [v.x + dx, v.y + dy, v.z + dz].join(',')
-      const idx = indexMap.get(key)
+      const idx = indexMap.get(hash(v.x + dx, v.y + dy, v.z + dz))
       if (idx !== undefined) neighborMap[i].push(idx)
     })
     neighborMap[i].sort((a, b) => a - b)


### PR DESCRIPTION
## Summary
- replace string-based coordinate map with numeric hash in FCC lattice generator
- update neighbor lookup to use numeric hashing
- extend lattice tests for uniqueness and multi-radius integrity

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68bc4b36bcb4832090000e5287ab0bfd