### PR TITLE
chore: document node requirement and import perf hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Scaffolded with Vite + React + TypeScript. Includes a Three.js scene rendering a rotating dodecahedron with spheres on its vertices.
 
+## Requirements
+- Node.js 20.19 or newer (or >=22.12)
+
 ## Scripts
 - `pnpm install` installs dependencies.
 - `pnpm run dev` starts a development server at http://localhost:5173.

--- a/bench.ts
+++ b/bench.ts
@@ -1,4 +1,5 @@
 import { step } from './src/ca'
+import { performance } from 'perf_hooks'
 
 const N = 100000
 const iterations = 100


### PR DESCRIPTION
## Summary
- import `performance` from `perf_hooks` in benchmark script
- note minimum Node.js version in README

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_b_68bc4c6c849083209c75be6b8840ca25